### PR TITLE
Specify switches to use in elevate command

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,10 +11,13 @@ var getElevatePath = function() {
 }
 
 module.exports = {
-	exec: function (cmd, options, callback) {
+	exec: function (cmd, options, callback, switches) {
 		var elevatePath = getElevatePath();
-
-		var args = ["-c", "-w", cmd].concat(options);
+		
+		if (switches === null) {
+			switches = ['-c', '-w'];
+		}
+		var args = switches.concat(cmd, options);
 
 		return childProcess.execFile(elevatePath, args, callback);
 	}


### PR DESCRIPTION
This allows changing the switches so that `-k` can be used instead of `-c`. This gives more flexibility than hardcoding the values.